### PR TITLE
Recursive

### DIFF
--- a/crypto/src/hash/blake/mod.rs
+++ b/crypto/src/hash/blake/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 /// Implementation of the [Hasher](super::Hasher) trait for BLAKE3 hash function with 256-bit
 /// output.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq,Clone)]
 pub struct Blake3_256<B: StarkField>(PhantomData<B>);
 
 impl<B: StarkField> Hasher for Blake3_256<B> {

--- a/fri/src/folding/mod.rs
+++ b/fri/src/folding/mod.rs
@@ -163,6 +163,7 @@ pub fn fold_positions(
 ) -> Vec<usize> {
     let target_domain_size = source_domain_size / folding_factor;
 
+    //println!("target_domain size {:?}", target_domain_size);
     let mut result = Vec::new();
     for position in positions {
         let position = position % target_domain_size;

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -80,6 +80,7 @@ pub use options::FriOptions;
 
 mod proof;
 pub use proof::FriProof;
+pub use proof::FriProof_;
 
 mod errors;
 pub use errors::VerifierError;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -381,3 +381,371 @@ impl Deserializable for FriProofLayer {
         Ok(FriProofLayer { values, paths })
     }
 }
+
+// FRI PROOF QUERY
+// ================================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FriProofQuery {
+    pub values: Vec<u8>,
+    pub paths: Vec<u8>,
+}
+
+impl FriProofQuery {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Creates a new proof layer from the specified query values and the corresponding Merkle
+    /// paths aggregated into a single batch Merkle proof.
+    ///
+    /// # Panics
+    /// Panics if `query_values` is an empty slice.
+    pub(crate) fn new<H: Hasher, E: FieldElement, const N: usize>(
+        query_values: Vec<[E; N]>,
+        merkle_proof: BatchMerkleProof<H>,
+    ) -> Self {
+        assert!(!query_values.is_empty(), "query values cannot be empty");
+
+        // TODO: add debug check that values actually hash into the leaf nodes of the batch proof
+
+        // concatenate all query values and all internal Merkle proof nodes into vectors of bytes;
+        // we care about internal nodes only because leaf nodes can be reconstructed from hashes
+        // of query values
+        FriProofQuery {
+            values: query_values.to_bytes(),
+            paths: merkle_proof.serialize_nodes(),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the size of this proof layer in bytes.
+    pub fn size(&self) -> usize {
+        // +4 for length of values, +4 for length of paths
+        self.values.len() + 4 + self.paths.len() + 4
+    }
+
+    // PARSING
+    // --------------------------------------------------------------------------------------------
+    /// Decomposes this layer into a combination of query values and corresponding Merkle
+    /// authentication paths (grouped together into a single batch Merkle proof).
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * This layer does not contain at least one query.
+    /// * Parsing of any of the query values or the corresponding Merkle paths fails.
+    /// * Not all bytes have been consumed while parsing this layer.
+    pub fn parse<H, E>(
+        self,
+        domain_size: usize,
+        folding_factor: usize,
+    ) -> Result<(Vec<E>, BatchMerkleProof<H>), DeserializationError>
+    where
+        E: FieldElement,
+        H: ElementHasher<BaseField = E::BaseField>,
+    {
+        // make sure the number of value bytes can be parsed into a whole number of queries
+        let num_query_bytes = E::ELEMENT_BYTES * folding_factor;
+        if self.values.len() % num_query_bytes != 0 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "number of value bytes ({}) does not divide into whole number of queries",
+                self.values.len(),
+            )));
+        }
+
+        let num_queries = self.values.len() / num_query_bytes;
+        if num_queries == 0 {
+            return Err(DeserializationError::InvalidValue(
+                "a FRI layer must contain at least one query".to_string(),
+            ));
+        }
+        let mut hashed_queries = vec![H::Digest::default(); num_queries];
+        let mut query_values = Vec::with_capacity(num_queries * folding_factor);
+
+        // read bytes corresponding to each query, convert them into field elements,
+        // and also hash them to build leaf nodes of the batch Merkle proof
+        let mut reader = SliceReader::new(&self.values);
+        for query_hash in hashed_queries.iter_mut() {
+            let mut qe = E::read_batch_from(&mut reader, folding_factor)?;
+            *query_hash = H::hash_elements(&qe);
+            query_values.append(&mut qe);
+        }
+        if reader.has_more_bytes() {
+            return Err(DeserializationError::UnconsumedBytes);
+        }
+
+        // build batch Merkle proof
+        let mut reader = SliceReader::new(&self.paths);
+        let tree_depth = log2(domain_size) as u8;
+        let merkle_proof = BatchMerkleProof::deserialize(&mut reader, hashed_queries, tree_depth)?;
+        if reader.has_more_bytes() {
+            return Err(DeserializationError::UnconsumedBytes);
+        }
+
+        Ok((query_values, merkle_proof))
+    }
+}
+
+// SERIALIZATION / DESERIALIZATION
+// ------------------------------------------------------------------------------------------------
+
+impl Serializable for FriProofQuery {
+    /// Serializes this proof layer and writes the resulting bytes to the specified `target`.
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // write value bytes
+        target.write_u32(self.values.len() as u32);
+        target.write_u8_slice(&self.values);
+
+        // write path bytes
+        target.write_u32(self.paths.len() as u32);
+        target.write_u8_slice(&self.paths);
+    }
+}
+
+impl Deserializable for FriProofQuery {
+    /// Reads a single proof layer form the `source` and returns it.
+    ///
+    /// # Errors
+    /// Returns an error if a valid layer could not be read from the specified source.
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        // read values
+        let num_value_bytes = source.read_u32()?;
+        if num_value_bytes == 0 {
+            return Err(DeserializationError::InvalidValue(
+                "a FRI proof layer must contain at least one queried evaluation".to_string(),
+            ));
+        }
+        let values = source.read_u8_vec(num_value_bytes as usize)?;
+
+        // read paths
+        let num_paths_bytes = source.read_u32()?;
+        let paths = source.read_u8_vec(num_paths_bytes as usize)?;
+
+        Ok(FriProofQuery { values, paths })
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FriProof_ {
+    pub queries: Vec<Vec<FriProofQuery>>,
+    remainder: Vec<u8>,
+    num_partitions: u8, // stored as power of 2
+}
+
+impl FriProof_ {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Creates a new FRI proof from the provided layers and remainder values.
+    ///
+    /// # Panics
+    /// Panics if:
+    /// * Number of remainder elements zero or is not a power of two.
+    /// * `num_partitions` is zero or is not a power of two.
+    pub(crate) fn new<E: FieldElement>(
+    queries: Vec<Vec<FriProofQuery>>,
+        remainder: Vec<E>,
+        num_partitions: usize,
+    ) -> Self {
+        assert!(
+            !remainder.is_empty(),
+            "number of remainder elements must be greater than zero"
+        );
+        assert!(
+            remainder.len().is_power_of_two(),
+            "size of the remainder must be a power of two, but was {}",
+            remainder.len()
+        );
+        assert!(
+            num_partitions > 0,
+            "number of partitions must be greater than zero"
+        );
+        assert!(
+            num_partitions.is_power_of_two(),
+            "number of partitions must be a power of two, but was {}",
+            num_partitions
+        );
+        FriProof_ {
+            queries,
+            remainder: remainder.to_bytes(),
+            num_partitions: num_partitions.trailing_zeros() as u8,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the number of layers in this proof.
+    pub fn num_layers(&self) -> usize {
+        self.queries.last().unwrap().len()
+    }
+
+    /// Returns the number of remainder elements in this proof.
+    ///
+    /// The number of elements is computed by dividing the number of remainder bytes by the size
+    /// of the field element specified by `E` type parameter.
+    pub fn num_remainder_elements<E: FieldElement>(&self) -> usize {
+        self.remainder.len() / E::ELEMENT_BYTES
+    }
+
+    /// Returns the number of partitions used during proof generation.
+    pub fn num_partitions(&self) -> usize {
+        2usize.pow(self.num_partitions as u32)
+    }
+
+    /// Returns the size of this proof in bytes.
+    pub fn size(&self) -> usize {
+        // +1 for number of layers, +1 for remainder length, +1 for number of partitions
+        self.queries
+            .iter().flatten()
+            .fold(self.remainder.len() + 3, |acc, queries| acc + (*queries).size())
+    }
+
+    
+
+    // PARSING
+    // --------------------------------------------------------------------------------------------
+/*
+    /// Decomposes this proof into vectors of query values for each layer and corresponding Merkle
+    /// authentication paths for each query (grouped into batch Merkle proofs).
+    ///
+    /// # Panics
+    /// Panics if:
+    /// * `domain_size` is not a power of two.
+    /// * `folding_factor` is smaller than two or is not a power of two.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * This proof is not consistent with the specified `domain_size` and `folding_factor`.
+    /// * Any of the layers could not be parsed successfully.
+    #[allow(clippy::type_complexity)]
+    pub fn parse_layers<H, E>(
+        self,
+        mut domain_size: usize,
+        folding_factor: usize,
+    ) -> Result<(Vec<Vec<E>>, Vec<BatchMerkleProof<H>>), DeserializationError>
+    where
+        E: FieldElement,
+        H: ElementHasher<BaseField = E::BaseField>,
+    {
+        assert!(
+            domain_size.is_power_of_two(),
+            "domain size must be a power of two"
+        );
+        assert!(
+            folding_factor.is_power_of_two(),
+            "folding factor must be a power of two"
+        );
+        assert!(folding_factor > 1, "folding factor must be greater than 1");
+
+        let mut layer_proofs = Vec::new();
+        let mut layer_queries = Vec::new();
+        let num_remainder_elements = self.num_remainder_elements::<E>();
+
+        // parse all layers
+        for (i, layer) in self.layers.into_iter().enumerate() {
+            domain_size /= folding_factor;
+            let (qv, mp) = layer.parse(domain_size, folding_factor).map_err(|err| {
+                DeserializationError::InvalidValue(format!(
+                    "failed to parse FRI layer {}: {}",
+                    i, err
+                ))
+            })?;
+            layer_proofs.push(mp);
+            layer_queries.push(qv);
+        }
+
+        // make sure the remaining domain size matches remainder length
+        if domain_size != num_remainder_elements {
+            return Err(DeserializationError::InvalidValue(format!(
+                "FRI remainder domain size must be {}, but was {}",
+                num_remainder_elements, domain_size,
+            )));
+        }
+
+        Ok((layer_queries, layer_proofs))
+    }
+    */
+
+    /// Returns a vector of remainder values (last FRI layer) parsed from this proof.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * The number of remainder values implied by a combination of `E` type parameter and
+    ///   the number of remainder bytes in this proof is not a power of two.
+    /// * Any of the remainder values could not be parsed correctly.
+    /// * Not all bytes have been consumed while parsing remainder values.
+    pub fn parse_remainder<E: FieldElement>(&self) -> Result<Vec<E>, DeserializationError> {
+        let num_elements = self.num_remainder_elements::<E>();
+        if !num_elements.is_power_of_two() {
+            return Err(DeserializationError::InvalidValue(format!(
+                "number of remainder values must be a power of two, but {} was implied",
+                num_elements
+            )));
+        }
+        let mut reader = SliceReader::new(&self.remainder);
+        let remainder = E::read_batch_from(&mut reader, num_elements).map_err(|err| {
+            DeserializationError::InvalidValue(format!("failed to parse FRI remainder: {}", err))
+        })?;
+        if reader.has_more_bytes() {
+            return Err(DeserializationError::UnconsumedBytes);
+        }
+        Ok(remainder)
+    }
+}
+/*
+// SERIALIZATION / DESERIALIZATION
+// ------------------------------------------------------------------------------------------------
+
+impl Serializable for FriProof_ {
+    /// Serializes `self` and writes the resulting bytes into the `target` writer.
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // write layers
+        target.write_u8(self.layers.len() as u8);
+        for layer in self.layers.iter() {
+            layer.write_into(target);
+        }
+
+        // write remainder
+        target.write_u16(self.remainder.len() as u16);
+        target.write_u8_slice(&self.remainder);
+
+        // write number of partitions
+        target.write_u8(self.num_partitions);
+    }
+}
+
+impl Deserializable for FriProof_ {
+    /// Reads a FRI proof from the specified `source` and returns the result.
+    ///
+    /// # Errors
+    /// Returns an error if a valid proof could not be read from the source.
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        // read layers
+        let num_layers = source.read_u8()? as usize;
+        let layers = FriProofLayer::read_batch_from(source, num_layers)?;
+
+        // read remainder
+        let num_remainder_bytes = source.read_u16()? as usize;
+        let remainder = source.read_u8_vec(num_remainder_bytes)?;
+
+        // read number of partitions
+        let num_partitions = source.read_u8()?;
+
+        Ok(FriProof_ {
+            layers,
+            remainder,
+            num_partitions,
+        })
+    }
+}
+*/

--- a/fri/src/prover/mod.rs
+++ b/fri/src/prover/mod.rs
@@ -389,8 +389,7 @@ fn query_layer<B: StarkField, E: FieldElement<BaseField = B>, H: Hasher, const N
     FriProofLayer::new(queried_values, proof)
 }
 
-/// Builds a single proof layer by querying the evaluations of the passed in FRI layer at the
-/// specified position.
+
 fn query_layer_one<
     B: StarkField,
     E: FieldElement<BaseField = B>,
@@ -401,20 +400,18 @@ fn query_layer_one<
     position: &[usize],
     index: usize,
 ) -> FriProofQuery {
-    // build Merkle authentication paths for all query positions
     let proof = layer
         .tree
         .prove_batch(position)
         .expect("failed to generate a Merkle proof for FRI layer queries");
 
-    // build a list of polynomial evaluations at each position; since evaluations in FRI layers
-    // are stored in transposed form, a position refers to N evaluations which are committed
-    // in a single leaf
+    
     let evaluations: &[[E; N]] = group_slice_elements(&layer.evaluations);
     let queried_value: [E; N] = evaluations[position[0]];
-    //if index == 0 {
+    if index == 1 {
         //println!("Proof correct {:?}", proof);
-    //}
+        println!("Queried values prover {:?}",queried_value);
+    }
     //println!("Queried values {:?}", queried_value);
     FriProofQuery::new(vec![queried_value], proof)
 }

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -6,7 +6,7 @@
 use super::{DefaultProverChannel, FriProver};
 use crate::{
     verifier::{DefaultVerifierChannel, FriVerifier},
-    FriOptions, FriProof, VerifierError,
+    FriOptions, FriProof_, VerifierError,
 };
 use crypto::{hashers::Blake3_256, Hasher, RandomCoin};
 use math::{fft, fields::f128::BaseElement, FieldElement};
@@ -83,7 +83,7 @@ pub fn build_evaluations(trace_length: usize, lde_blowup: usize) -> Vec<BaseElem
 }
 
 pub fn verify_proof(
-    proof: FriProof,
+    proof: FriProof_,
     commitments: Vec<<Blake3 as Hasher>::Digest>,
     evaluations: &[BaseElement],
     max_degree: usize,
@@ -92,11 +92,11 @@ pub fn verify_proof(
     options: &FriOptions,
 ) -> Result<(), VerifierError> {
     // test proof serialization / deserialization
-    let mut proof_bytes = Vec::new();
-    proof.write_into(&mut proof_bytes);
+    //let mut proof_bytes = Vec::new();
+    //proof.write_into(&mut proof_bytes);
 
-    let mut reader = SliceReader::new(&proof_bytes);
-    let proof = FriProof::read_from(&mut reader).unwrap();
+    //let mut reader = SliceReader::new(&proof_bytes);
+    //let proof = FriProof::read_from(&mut reader).unwrap();
 
     // verify the proof
     let mut channel = DefaultVerifierChannel::<BaseElement, Blake3>::new(

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -37,6 +37,28 @@ pub fn map_positions_to_indexes(
     result
 }
 
+/// Maps a position in the evaluation domain to its index in commitment Merkle tree.
+pub fn map_positions_to_index(
+    position: &usize,
+    source_domain_size: usize,
+    folding_factor: usize,
+    num_partitions: usize,
+) -> usize {
+    // if there was only 1 partition, order of elements in the commitment tree
+    // is the same as the order of elements in the evaluation domain
+    if num_partitions == 1 {
+        return *position;
+    }
+
+    let target_domain_size = source_domain_size / folding_factor;
+    let partition_size = target_domain_size / num_partitions;
+
+    let partition_idx = position % num_partitions;
+    let local_idx = (position - partition_idx) / num_partitions;
+    let position = partition_idx * partition_size + local_idx;
+
+    position
+}
 /// Hashes each of the arrays in the provided slice and returns a vector of resulting hashes.
 pub fn hash_values<H, E, const N: usize>(values: &[[E; N]]) -> Vec<H::Digest>
 where

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -38,7 +38,7 @@ pub fn map_positions_to_indexes(
 }
 
 /// Maps a position in the evaluation domain to its index in commitment Merkle tree.
-pub fn map_positions_to_index(
+pub fn map_position_to_index(
     position: &usize,
     source_domain_size: usize,
     folding_factor: usize,
@@ -59,6 +59,7 @@ pub fn map_positions_to_index(
 
     position
 }
+
 /// Hashes each of the arrays in the provided slice and returns a vector of resulting hashes.
 pub fn hash_values<H, E, const N: usize>(values: &[[E; N]]) -> Vec<H::Digest>
 where


### PR DESCRIPTION
This PR implements a proposed modification to the FRI verifier in order to make it more "recursion friendly". Ideally, the FRI prover should remain untouched and a parser should be implemented in order to turn the currently generated FRI proofs into a format that the FRI verifier in this PR can work on. However, the FRI prover is also modified as it was better, understanding wise, and easier during the development of the new verifier.
A few points worth noting:

1. New data structures, based on the already implemented ones, are introduced. Little thought was given to the efficiency or code esthetics but this should be considered once we settle on the core ideas.  
2. In some places, especially functions on queries, a vector of inputs consisting of only one variable is used in order to be able to use the already existing helper functions. Clearly this is unnecessary and these portions should be adapted appropriately.
3. There are still remnants of BatchMerkleProof's in the code, and again, this is kept only to make some old parsing functions work as is and will be changed to the functions that verifies a single Merkle proof.