### PR TITLE
feat: proof parser + query-wise verifier

### DIFF
--- a/crypto/src/merkle/proofs.rs
+++ b/crypto/src/merkle/proofs.rs
@@ -255,6 +255,169 @@ impl<H: Hasher> BatchMerkleProof<H> {
         v.remove(&1).ok_or(MerkleTreeError::InvalidProof)
     }
 
+    /// Computes the uncompressed Merkle paths which aggregate to this proof.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * No indexes were provided (i.e., `indexes` is an empty slice).
+    /// * Number of provided indexes is greater than 255.
+    pub fn unbatch(&self, indexes: &[usize]) -> Result<Vec<Vec<H::Digest>>, MerkleTreeError> {
+        if indexes.is_empty() {
+            return Err(MerkleTreeError::TooFewLeafIndexes);
+        }
+        if indexes.len() > MAX_PATHS {
+            return Err(MerkleTreeError::TooManyLeafIndexes(
+                MAX_PATHS,
+                indexes.len(),
+            ));
+        }
+        let mut leaves = self.leaves.clone();
+        leaves.reverse();
+
+        let mut partial_tree = Vec::with_capacity(1 << (self.depth + 1));
+
+        for _ in 0..(1 << (self.depth + 1)) {
+            partial_tree.push(H::Digest::default());
+        }
+
+        for i in indexes {
+            if let Some(leave) = leaves.pop() {
+                partial_tree[*i + (1 << (self.depth))] = leave;
+            } else {
+                println!("Error in poping");
+            }
+        }
+
+        let mut buf = [H::Digest::default(); 2];
+        let mut v = BTreeMap::new();
+
+        // replace odd indexes, offset, and sort in ascending order
+        let original_indexes = indexes.clone();
+        let index_map = super::map_indexes(indexes, self.depth as usize)?;
+        let indexes = super::normalize_indexes(indexes);
+        if indexes.len() != self.nodes.len() {
+            return Err(MerkleTreeError::InvalidProof);
+        }
+
+        // for each index use values to compute parent nodes
+        let offset = 2usize.pow(self.depth as u32);
+        let mut next_indexes: Vec<usize> = Vec::new();
+        let mut proof_pointers: Vec<usize> = Vec::with_capacity(indexes.len());
+        for (i, index) in indexes.into_iter().enumerate() {
+            // copy values of leaf sibling leaf nodes into the buffer
+            match index_map.get(&index) {
+                Some(&index1) => {
+                    if self.leaves.len() <= index1 {
+                        return Err(MerkleTreeError::InvalidProof);
+                    }
+                    buf[0] = self.leaves[index1];
+                    match index_map.get(&(index + 1)) {
+                        Some(&index2) => {
+                            if self.leaves.len() <= index2 {
+                                return Err(MerkleTreeError::InvalidProof);
+                            }
+                            buf[1] = self.leaves[index2];
+                            proof_pointers.push(0);
+                        }
+                        None => {
+                            if self.nodes[i].is_empty() {
+                                return Err(MerkleTreeError::InvalidProof);
+                            }
+                            buf[1] = self.nodes[i][0];
+                            proof_pointers.push(1);
+                        }
+                    }
+                }
+                None => {
+                    if self.nodes[i].is_empty() {
+                        return Err(MerkleTreeError::InvalidProof);
+                    }
+                    buf[0] = self.nodes[i][0];
+                    match index_map.get(&(index + 1)) {
+                        Some(&index2) => {
+                            if self.leaves.len() <= index2 {
+                                return Err(MerkleTreeError::InvalidProof);
+                            }
+                            buf[1] = self.leaves[index2];
+                        }
+                        None => return Err(MerkleTreeError::InvalidProof),
+                    }
+                    proof_pointers.push(1);
+                }
+            }
+
+            // hash sibling nodes into their parent
+            let parent = H::merge(&buf);
+            partial_tree[(offset + index)] = buf[0];
+            partial_tree[(offset + index)^1] = buf[1];
+            let parent_index = (offset + index) >> 1;
+            v.insert(parent_index, parent);
+            next_indexes.push(parent_index);
+            partial_tree[parent_index] = parent;
+        }
+
+        // iteratively move up, until we get to the root
+        for _ in 1..self.depth {
+            let indexes = next_indexes.clone();
+            next_indexes.truncate(0);
+
+            let mut i = 0;
+            while i < indexes.len() {
+                let node_index = indexes[i];
+                let sibling_index = node_index ^ 1;
+
+                // determine the sibling
+                let sibling: H::Digest;
+                if i + 1 < indexes.len() && indexes[i + 1] == sibling_index {
+                    sibling = match v.get(&sibling_index) {
+                        Some(sibling) => *sibling,
+                        None => return Err(MerkleTreeError::InvalidProof),
+                    };
+                    i += 1;
+                } else {
+                    let pointer = proof_pointers[i];
+                    if self.nodes[i].len() <= pointer {
+                        return Err(MerkleTreeError::InvalidProof);
+                    }
+                    sibling = self.nodes[i][pointer];
+                    proof_pointers[i] += 1;
+                }
+
+                // get the node from the map of hashed nodes
+                let node = match v.get(&node_index) {
+                    Some(node) => node,
+                    None => return Err(MerkleTreeError::InvalidProof),
+                };
+
+                // compute parent node from node and sibling
+                if node_index & 1 != 0 {
+                    buf[0] = sibling;
+                    buf[1] = *node;
+                    partial_tree[node_index ^ 1] = sibling;
+                } else {
+                    buf[0] = *node;
+                    buf[1] = sibling;
+                    partial_tree[node_index ^ 1] = sibling;
+                }
+                let parent = H::merge(&buf);
+
+                // add the parent node to the next set of nodes
+                let parent_index = node_index >> 1;
+                v.insert(parent_index, parent);
+                next_indexes.push(parent_index);
+                partial_tree[parent_index] = parent;
+
+                i += 1;
+            }
+        }
+        let mut result = vec![];
+        for i in original_indexes {
+            result.push(get_path::<H>(*i, &partial_tree).to_vec());
+        }
+
+        Ok(result)
+    }
+
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
@@ -342,4 +505,16 @@ impl<H: Hasher> BatchMerkleProof<H> {
 /// immediately follows the left node.
 fn are_siblings(left: usize, right: usize) -> bool {
     left & 1 == 0 && right - 1 == left
+}
+
+/// Computes the Merkle path from the computed (partial) tree.
+pub fn get_path<H: Hasher>(index: usize, tree: &[H::Digest]) -> Vec<H::Digest> {
+    let mut index = index + tree.len() / 2;
+    let mut proof = vec![tree[index]];
+    while index > 1 {
+        proof.push(tree[index ^ 1]);
+        index >>= 1;
+    }
+
+    return proof;
 }

--- a/crypto/src/merkle/tests.rs
+++ b/crypto/src/merkle/tests.rs
@@ -232,6 +232,30 @@ fn verify_batch() {
     assert!(MerkleTree::verify_batch(tree.root(), &[0, 1, 2, 3, 4, 5, 6, 7], &proof).is_ok());
 }
 
+#[test]
+fn verify_unbatch() {
+    let leaves = Digest256::bytes_as_digests(&LEAVES8).to_vec();
+    let tree = MerkleTree::<Blake3_256>::new(leaves).unwrap();
+
+    let proof1 = tree.prove(1).unwrap();
+    let proof2 = tree.prove(2).unwrap();
+    let proof1_2 = tree.prove_batch(&[1, 2]).unwrap();
+    let result = proof1_2.unbatch(&[1, 2]).unwrap();
+
+    assert_eq!(proof1, result[0]);
+    assert_eq!(proof2, result[1]);
+
+    let proof3 = tree.prove(3).unwrap();
+    let proof4 = tree.prove(4).unwrap();
+    let proof6 = tree.prove(5).unwrap();
+    let proof3_4_6 = tree.prove_batch(&[3, 4, 5]).unwrap();
+    let result = proof3_4_6.unbatch(&[3, 4, 5]).unwrap();
+
+    assert_eq!(proof3, result[0]);
+    assert_eq!(proof4, result[1]);
+    assert_eq!(proof6, result[2]);
+}
+
 proptest! {
     #[test]
     fn prove_n_verify(tree in random_blake3_merkle_tree(128),
@@ -268,6 +292,24 @@ proptest! {
         let proof2 = BatchMerkleProof::from_paths(&paths, &indices);
 
         prop_assert!(proof1 == proof2);
+    }
+    
+    #[test]
+    fn unbatch(tree in random_blake3_merkle_tree(32),
+                      proof_indices in prop::collection::vec(any::<prop::sample::Index>(), 1..30)
+    )  {
+        let mut indices: Vec<usize> = proof_indices.iter().map(|idx| idx.index(32)).collect();
+        indices.sort_unstable(); indices.dedup();
+        let proof1 = tree.prove_batch(&indices[..]).unwrap();
+
+        let mut paths_expected = Vec::new();
+        for &idx in indices.iter() {
+            paths_expected.push(tree.prove(idx).unwrap());
+        }
+
+        let paths = proof1.unbatch(&indices);
+
+        prop_assert!(paths_expected == paths.unwrap());
     }
 }
 

--- a/fri/src/prover/tests.rs
+++ b/fri/src/prover/tests.rs
@@ -112,5 +112,6 @@ pub fn verify_proof(
         .iter()
         .map(|&p| evaluations[p])
         .collect::<Vec<_>>();
-    verifier.verify(&mut channel, &queried_evaluations, &positions)
+    //verifier.verify(&mut channel, &queried_evaluations, &positions)
+    verifier.verify_query(&mut channel, &queried_evaluations, positions)
 }

--- a/fri/src/utils.rs
+++ b/fri/src/utils.rs
@@ -37,6 +37,29 @@ pub fn map_positions_to_indexes(
     result
 }
 
+/// Maps a position in the evaluation domain to its index in commitment Merkle tree.
+pub fn map_position_to_index(
+    position: &usize,
+    source_domain_size: usize,
+    folding_factor: usize,
+    num_partitions: usize,
+) -> usize {
+    // if there was only 1 partition, order of elements in the commitment tree
+    // is the same as the order of elements in the evaluation domain
+    if num_partitions == 1 {
+        return *position;
+    }
+
+    let target_domain_size = source_domain_size / folding_factor;
+    let partition_size = target_domain_size / num_partitions;
+
+    let partition_idx = position % num_partitions;
+    let local_idx = (position - partition_idx) / num_partitions;
+    let position = partition_idx * partition_size + local_idx;
+
+    position
+}
+
 /// Hashes each of the arrays in the provided slice and returns a vector of resulting hashes.
 pub fn hash_values<H, E, const N: usize>(values: &[[E; N]]) -> Vec<H::Digest>
 where

--- a/fri/src/verifier/channel.rs
+++ b/fri/src/verifier/channel.rs
@@ -3,7 +3,13 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use crate::{utils::hash_values, FriProof, VerifierError};
+use core::mem;
+
+use crate::{
+    folding::fold_positions,
+    utils::{hash_values, map_positions_to_indexes},
+    FriProof, VerifierError,
+};
 use crypto::{BatchMerkleProof, ElementHasher, Hasher, MerkleTree};
 use math::FieldElement;
 use utils::{collections::Vec, group_vector_elements, transpose_slice, DeserializationError};
@@ -64,6 +70,22 @@ pub trait VerifierChannel<E: FieldElement> {
 
     /// Reads and removes the remainder (last FRI layer) values from the channel.
     fn take_fri_remainder(&mut self) -> Vec<E>;
+
+    /// Reads the query positions and returns, for each query, the quotient group, of size N, which
+    /// corresponds to the folded position at the layer. These N-values are augmented with the
+    /// Merkle proof of their inclusion against the corresponding layer commitment.
+    fn unbatch<const N: usize>(
+        &self,
+        positions: &[usize],
+        domain_size: usize,
+        folding_factor: usize,
+        layer_commitments: Vec<<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest>,
+    ) -> Vec<
+        Vec<(
+            Vec<<<Self as VerifierChannel<E>>::Hasher as Hasher>::Digest>,
+            [E; N],
+        )>,
+    >;
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
@@ -194,5 +216,75 @@ where
 
     fn take_fri_remainder(&mut self) -> Vec<E> {
         self.remainder.clone()
+    }
+    
+    fn unbatch<const N: usize>(
+        &self,
+        positions_: &[usize],
+        domain_size: usize,
+        folding_factor: usize,
+        layer_commitments: Vec<H::Digest>,
+    ) -> Vec<Vec<(Vec<H::Digest>, [E; N])>> {
+        let queries = self.layer_queries.clone();
+        let mut current_domain_size = domain_size;
+        let mut positions = positions_.to_vec();
+        let depth = layer_commitments.len() - 1;
+        let mut result: Vec<Vec<(usize, Vec<<H as Hasher>::Digest>, [E; N])>> = Vec::new();
+
+        for i in 0..depth {
+            let mut folded_positions =
+                fold_positions(&positions, current_domain_size, folding_factor);
+            let position_indexes = map_positions_to_indexes(
+                &folded_positions,
+                current_domain_size,
+                folding_factor,
+                self.num_partitions,
+            );
+            assert_eq!(position_indexes, folded_positions);
+
+            let unbatched_proof = self.layer_proofs[i].unbatch(&position_indexes).unwrap();
+            let x = group_vector_elements::<E, N>(queries[i].clone());
+            assert_eq!(x.len(), unbatched_proof.len());
+
+            let partial_result = {
+                let mut partial_result: Vec<_> = Vec::new();
+                for j in 0..unbatched_proof.len() {
+                    let tmp = (position_indexes[j], unbatched_proof[j].clone(), x[j]);
+                    partial_result.push(tmp);
+                }
+                partial_result
+            };
+            result.push(partial_result);
+            mem::swap(&mut positions, &mut folded_positions);
+            current_domain_size = current_domain_size / folding_factor;
+        }
+
+        let mut final_result: Vec<Vec<(Vec<<H as Hasher>::Digest>, [E; N])>> = Vec::new();
+        for p in positions_.iter() {
+            let mut current_domain_size = domain_size;
+            let current_position = p;
+
+            let query_across_layers = {
+                let mut query_across_layers: Vec<(Vec<<H as Hasher>::Digest>, [E; N])> = Vec::new();
+                for i in 0..depth {
+                    current_domain_size = current_domain_size / folding_factor;
+                    let current_position = current_position % current_domain_size;
+                    let queries_current_layer = result[i].clone();
+
+                    let single_query = queries_current_layer
+                        .iter()
+                        .find(|(i, _, _)| *i == current_position)
+                        .unwrap();
+                    let single_query = ((*single_query).1.clone(), single_query.2);
+
+                    query_across_layers.push(single_query);
+                }
+                query_across_layers
+            };
+            final_result.push(query_across_layers);
+        }
+        assert!(final_result.len() == (*positions_).len());
+        assert!(final_result[0].len() == depth);
+        final_result
     }
 }

--- a/fri/src/verifier/mod.rs
+++ b/fri/src/verifier/mod.rs
@@ -5,9 +5,13 @@
 
 //! Contains an implementation of FRI verifier and associated components.
 
-use crate::{folding::fold_positions, utils::map_positions_to_indexes, FriOptions, VerifierError};
+use crate::{
+    folding::fold_positions,
+    utils::{map_position_to_index, map_positions_to_indexes},
+    FriOptions, VerifierError,
+};
 use core::{convert::TryInto, marker::PhantomData, mem};
-use crypto::{ElementHasher, RandomCoin};
+use crypto::{ElementHasher, MerkleTree, RandomCoin};
 use math::{fft, log2, polynom, FieldElement, StarkField};
 use utils::collections::Vec;
 
@@ -310,6 +314,177 @@ where
         let remainder = channel.read_remainder::<N>(remainder_commitment)?;
         for (&position, evaluation) in positions.iter().zip(evaluations) {
             if remainder[position] != evaluation {
+                return Err(VerifierError::InvalidRemainderFolding);
+            }
+        }
+
+        // make sure the remainder values satisfy the degree
+        verify_remainder(remainder, max_degree_plus_1 - 1)
+    }
+
+    // VERIFICATION PROCEDURE QUERY-WISE
+    // --------------------------------------------------------------------------------------------
+    /// Executes the query phase of the FRI protocol ONE QUERY POSITION AT A TIME.
+    ///
+    /// Returns `Ok(())` if values in the `evaluations` slice represent evaluations of a polynomial
+    /// with degree <= `max_poly_degree` at x coordinates specified by the `positions` slice.
+    ///
+    /// Thus, `positions` parameter represents the positions in the evaluation domain at which the
+    /// verifier queries the prover at the first FRI layer. Similarly, the `evaluations` parameter
+    /// specifies the evaluations of the polynomial at the first FRI layer returned by the prover
+    /// for these positions.
+    ///
+    /// Evaluations of layer polynomials for all subsequent FRI layers the verifier reads from the
+    /// specified `channel`.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * The length of `evaluations` is not equal to the length of `positions`.
+    /// * An unsupported folding factor was specified by the `options` for this verifier.
+    /// * Decommitments to polynomial evaluations don't match the commitment value at any of the
+    ///   FRI layers.
+    /// * The verifier detects an error in how the degree-respecting projection was applied
+    ///   at any of the FRI layers.
+    /// * The degree of the remainder at the last FRI layer is greater than the degree implied by
+    ///   `max_poly_degree` reduced by the folding factor at each FRI layer.
+    pub fn verify_query(
+        &self,
+        channel: &mut C,
+        evaluations: &[E],
+        positions: &[usize],
+    ) -> Result<(), VerifierError> {
+        if evaluations.len() != positions.len() {
+            return Err(VerifierError::NumPositionEvaluationMismatch(
+                positions.len(),
+                evaluations.len(),
+            ));
+        }
+
+        // static dispatch for folding factor parameter
+        let folding_factor = self.options.folding_factor();
+        match folding_factor {
+            4 => self.verify_generic_query::<4>(channel, evaluations, positions),
+            8 => self.verify_generic_query::<8>(channel, evaluations, positions),
+            16 => self.verify_generic_query::<16>(channel, evaluations, positions),
+            _ => Err(VerifierError::UnsupportedFoldingFactor(folding_factor)),
+        }
+    }
+
+    /// This is the actual implementation of the verification procedure described above, but it
+    /// also takes folding factor as a generic parameter N.
+    fn verify_generic_query<const N: usize>(
+        &self,
+        channel: &mut C,
+        evaluations: &[E],
+        positions: &[usize],
+    ) -> Result<(), VerifierError> {
+        // pre-compute roots of unity used in computing x coordinates in the folded domain
+        let folding_roots = (0..N)
+            .map(|i| {
+                self.domain_generator
+                    .exp(((self.domain_size / N * i) as u64).into())
+            })
+            .collect::<Vec<_>>();
+
+        // 1 ----- verify the recursive components of the FRI proof -----------------------------------
+        let positions = positions.to_vec();
+        let evaluations = evaluations.to_vec();
+
+        let mut query;
+        let mut cur_pos = 0;
+        let mut dom_size;
+        let mut evaluation = E::ZERO;
+        let mut domain_generator;
+        let mut max_degree_plus_1 = self.max_poly_degree + 1;
+        let mut final_pos_eval: Vec<(usize, E)> = vec![];
+
+        // The queries in a vertical configuration
+        let queries = channel.unbatch::<N>(
+            &positions,
+            self.domain_size,
+            self.options.folding_factor(),
+            self.layer_commitments.clone(),
+        );
+        // The number of queries provided by the prover is the same as the number of queries requested by the verifier
+        assert!(queries.len() == positions.len());
+        // Sanity check
+        assert!(queries[0].len() == self.options.num_fri_layers(self.domain_size));
+        for (index, position) in positions.iter().enumerate() {
+
+            final_pos_eval.push((cur_pos, evaluation));
+            query = queries[index].clone();
+            cur_pos = *position;
+            dom_size = self.domain_size;
+            evaluation = evaluations[index];
+            domain_generator = self.domain_generator;
+            max_degree_plus_1 = self.max_poly_degree + 1;
+
+            for depth in 0..self.options.num_fri_layers(self.domain_size) {
+                let target_domain_size = dom_size / self.options.folding_factor();
+                let (query_proof, query_values) = &query[depth];
+
+                let folded_pos = cur_pos % target_domain_size;
+                let position_index = map_position_to_index(
+                    &folded_pos,
+                    dom_size,
+                    self.options.folding_factor(),
+                    self.num_partitions,
+                );
+
+                let layer_commitment = self.layer_commitments[depth];
+
+                MerkleTree::<H>::verify(layer_commitment, position_index, &query_proof)
+                    .map_err(|_| VerifierError::LayerCommitmentMismatch)?;
+
+                let query_value = query_values[cur_pos / target_domain_size];
+
+                if evaluation != query_value {
+                    return Err(VerifierError::InvalidLayerFolding(depth));
+                }
+
+                #[rustfmt::skip]
+                let xe = domain_generator.exp((folded_pos as u64).into()) * self.options.domain_offset();
+                let xs: [E; N] = folding_roots
+                    .iter()
+                    .map(|&r| E::from(xe * r))
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap();
+                let row_poly = polynom::interpolate(&xs, query_values, true);
+
+                let alpha = self.layer_alphas[depth];
+
+                // check that when the polynomials are evaluated at alpha, the result is equal to
+                // the corresponding column value
+
+                let evaluation_new = polynom::eval(&row_poly, alpha);
+                evaluation = evaluation_new;
+
+                // make sure next degree reduction does not result in degree truncation
+                if max_degree_plus_1 % N != 0 {
+                    return Err(VerifierError::DegreeTruncation(
+                        max_degree_plus_1 - 1,
+                        N,
+                        depth,
+                    ));
+                }
+
+                // update variables for the next iteration of the loop
+                max_degree_plus_1 /= N;
+                domain_generator = domain_generator.exp((N as u32).into());
+                cur_pos = folded_pos;
+                dom_size /= N;
+            }
+        }
+
+        // 2 ----- verify the remainder of the FRI proof ----------------------------------------------
+
+        // read the remainder from the channel and make sure it matches with the columns
+        // of the previous layer
+        let remainder_commitment = self.layer_commitments.last().unwrap();
+        let remainder = channel.read_remainder::<N>(remainder_commitment)?;
+        for (pos, eval) in final_pos_eval.iter().skip(1) {
+            if remainder[*pos] != *eval {
                 return Err(VerifierError::InvalidRemainderFolding);
             }
         }


### PR DESCRIPTION
This PR proposes a draft implementation of a FRI verifier which runs the query phase of the FRI protocol in a query-by-query fashion. To do this, this PR also includes a potential modification to the verifier part of the channel so that the proof generated by the prover, which looks at all the queries in certain layer in one go, can be parsed for the new verifier implementation in this PR.
The interface of both the `unbatch` function as well as the `verifiy_generic_query` function is, in my opinion, suboptimal. The reason being that, in order to parse the proof, the `unbatch` function requires the array of queried positions and this makes the design of the interfaces, based on the current one, a challenge.