### PR TITLE
Optimize constraint evaluation

### DIFF
--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -14,7 +14,7 @@ use utils::collections::Vec;
 pub struct AirContext<B: StarkField> {
     pub(super) options: ProofOptions,
     pub(super) trace_info: TraceInfo,
-    pub(super) main_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
+    pub main_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
     pub(super) aux_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
     pub(super) num_main_assertions: usize,
     pub(super) num_aux_assertions: usize,

--- a/air/src/air/context.rs
+++ b/air/src/air/context.rs
@@ -15,7 +15,7 @@ pub struct AirContext<B: StarkField> {
     pub(super) options: ProofOptions,
     pub(super) trace_info: TraceInfo,
     pub main_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
-    pub(super) aux_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
+    pub aux_transition_constraint_degrees: Vec<TransitionConstraintDegree>,
     pub(super) num_main_assertions: usize,
     pub(super) num_aux_assertions: usize,
     pub(super) ce_blowup_factor: usize,

--- a/air/src/air/transition/mod.rs
+++ b/air/src/air/transition/mod.rs
@@ -199,9 +199,9 @@ impl<E: FieldElement> TransitionConstraints<E> {
 #[derive(Clone, Debug)]
 pub struct TransitionConstraintGroup<E: FieldElement> {
     degree: TransitionConstraintDegree,
-    degree_adjustment: u32,
-    indexes: Vec<usize>,
-    coefficients: Vec<(E, E)>,
+    pub degree_adjustment: u32,
+    pub indexes: Vec<usize>,
+    pub coefficients: Vec<(E, E)>,
 }
 
 impl<E: FieldElement> TransitionConstraintGroup<E> {

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -560,7 +560,7 @@ fn exp_acc<const N: usize>(base: BaseElement, tail: BaseElement) -> BaseElement 
 /// Montgomery reduction (variable time)
 #[allow(dead_code)]
 #[inline(always)]
-const fn mont_red_var(x: u128) -> u64 {
+const fn mont_red_cst(x: u128) -> u64 {
     const NPRIME: u64 = 4294967297;
     let q = (((x as u64) as u128) * (NPRIME as u128)) as u64;
     let m = (q as u128) * (M as u128);
@@ -574,7 +574,7 @@ const fn mont_red_var(x: u128) -> u64 {
 
 /// Montgomery reduction (constant time)
 #[inline(always)]
-const fn mont_red_cst(x: u128) -> u64 {
+const fn mont_red_var(x: u128) -> u64 {
     // See reference above for a description of the following implementation.
     let xl = x as u64;
     let xh = (x >> 64) as u64;

--- a/math/src/field/f64/mod.rs
+++ b/math/src/field/f64/mod.rs
@@ -101,15 +101,20 @@ impl FieldElement for BaseElement {
 
     #[inline]
     fn exp(self, power: Self::PositiveInteger) -> Self {
-        let mut b: Self;
-        let mut r = Self::ONE;
-        for i in (0..64).rev() {
-            r = r.square();
-            b = r;
-            b *= self;
-            // Constant-time branching
-            let mask = -(((power >> i) & 1 == 1) as i64) as u64;
-            r.0 ^= mask & (r.0 ^ b.0);
+        let mut b = self;
+
+        if power == 0 {
+            return Self::ONE;
+        } else if b == Self::ZERO {
+            return Self::ZERO;
+        }
+
+        let mut r = if power & 1 == 1 { b } else { Self::ONE };
+        for i in 1..64 - power.leading_zeros() {
+            b = b.square();
+            if (power >> i) & 1 == 1 {
+                r *= b;
+            }
         }
 
         r

--- a/prover/src/domain.rs
+++ b/prover/src/domain.rs
@@ -3,9 +3,9 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use air::Air;
-use math::{fft, log2, StarkField};
-use utils::collections::Vec;
+use air::{Air, ConstraintDivisor};
+use math::{fft, log2, StarkField, get_power_series};
+use utils::collections::{Vec, BTreeMap};
 
 // TYPES AND INTERFACES
 // ================================================================================================
@@ -23,6 +23,12 @@ pub struct StarkDomain<B: StarkField> {
 
     /// Offset of the low-degree extension domain.
     domain_offset: B,
+
+    /// [g^i for i in (0..ce_domain_size)] where g is the constraint evaluation domain generator.
+    pub domain_g: Vec<B>,
+
+    /// A mapping from adjustment degrees to domain_offset^adjustment_degree.
+    pub adj_map: BTreeMap<u32, B>,
 }
 
 // STARK DOMAIN IMPLEMENTATION
@@ -32,11 +38,41 @@ impl<B: StarkField> StarkDomain<B> {
     /// Returns a new STARK domain initialized with the provided `context`.
     pub fn new<A: Air<BaseField = B>>(air: &A) -> Self {
         let trace_twiddles = fft::get_twiddles(air.trace_length());
+        let dom_generator = B::get_root_of_unity(log2(air.ce_domain_size()));
+        let domain_offset = air.domain_offset();
+        let context = air.context();
+        let divisor: ConstraintDivisor<B> = ConstraintDivisor::from_transition(
+            context.trace_len(),
+            context.num_transition_exemptions(),
+        );
+        let div_deg = divisor.degree();
+        let main_constraint_degrees = context.main_transition_constraint_degrees.clone();
+        let trace_len = context.trace_len();
+        let comp_deg = context.composition_degree();
+        let target_deg = comp_deg + div_deg;
+
+        let mut adj_map = BTreeMap::new();
+
+        for degree in main_constraint_degrees.iter(){
+            let evaluation_degree = degree.get_evaluation_degree(trace_len);
+            let degree_adjustment = (target_deg - evaluation_degree) as u32;
+            let _ = adj_map.entry(degree_adjustment).or_insert_with(|| {domain_offset.exp(degree_adjustment.into())});
+            //insert(degree_adjustment, domain_offset.exp(degree_adjustment.into()));
+
+        }
+        
+
+        //let domain_g = (0..(air.ce_domain_size()))
+            //.map(|i|  (dom_generator).exp((i as u32).into()))// change this to multiply by g and push
+            //.collect();
+        let domain_g = get_power_series(dom_generator, air.ce_domain_size());
         StarkDomain {
             trace_twiddles,
             ce_domain_size: air.ce_domain_size(),
             ce_to_lde_blowup: air.lde_domain_size() / air.ce_domain_size(),
             domain_offset: air.domain_offset(),
+            domain_g,
+            adj_map
         }
     }
 


### PR DESCRIPTION
This PR implements an optimization that reduces the number of exponentiations used in constraint evaluation. It substitutes the exponentiation required for the computation of the degree adjustment with a precomputed table and some basic index arithmetic.  